### PR TITLE
Improve github actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+omit =
+    */migrations/*
+    */tests.py
+    */tests_*.py
+    */tests/*
+    venv/*
+    
+source = .
+[report]
+precision = 2
+show_missing = True

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -34,7 +34,7 @@ jobs:
         python src/manage.py check
         python src/manage.py makemigrations --dry-run --check
 
-    - name: Test
+    - name: Unit Tests
       env:
         PYTHONWARNINGS: all
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -3,9 +3,8 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -16,6 +15,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Cache pip
       uses: actions/cache@v2
       with:
@@ -25,12 +25,14 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install coveralls
         pip install -r requirements.txt
         echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> src/settings.py
+
     - name: Static tests
       env:
         PYTHONWARNINGS: all

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,6 +21,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install coveralls
         pip install -r requirements.txt
+        echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> settings.py
     - name: Test
       env:
         PYTHONWARNINGS: all

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -20,8 +20,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-{{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-{{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}
         restore-keys: |
+          ${{ runner.os }}-pip-{{ hashFiles('requirements.txt') }}
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
     - name: Install dependencies

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -31,14 +31,14 @@ jobs:
         pip install coveralls
         pip install -r requirements.txt
         echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> src/settings.py
-    - name: Static Tests
+    - name: Static tests
       env:
         PYTHONWARNINGS: all
       run: |
         python src/manage.py check
         python src/manage.py makemigrations --dry-run --check
 
-    - name: Unit Tests
+    - name: Unit tests
       env:
         PYTHONWARNINGS: all
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install coveralls wheel setuptools
+        pip install coveralls
         pip install -r requirements.txt
         echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> src/settings.py
     - name: Static Tests

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -27,14 +27,19 @@ jobs:
         pip install coveralls
         pip install -r requirements.txt
         echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> settings.py
+    - name: Static Tests
+      env:
+        PYTHONWARNINGS: all
+      run: |
+        python src/manage.py check
+        python src/manage.py makemigrations --dry-run --check
+
     - name: Test
       env:
         PYTHONWARNINGS: all
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NAME: github
       run: |
-        python src/manage.py check
-        python src/manage.py makemigrations --dry-run --check
         coverage run --omit="*/migrations*" --source="." src/manage.py test feedback
         coveralls
 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -34,6 +34,7 @@ jobs:
         COVERALLS_SERVICE_NAME: github
       run: |
         python src/manage.py check
+        python src/manage.py makemigrations --dry-run --check
         coverage run --omit="*/migrations*" --source="." src/manage.py test feedback
         coveralls
 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -31,7 +31,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install coveralls
         pip install -r requirements.txt
-        echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> src/settings.py
 
     - name: Static tests
       env:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -31,6 +31,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install coveralls
         pip install -r requirements.txt
+        echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> src/settings.py
 
     - name: Static tests
       env:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -20,7 +20,10 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip
+        key: ${{ runner.os }}-pip-{{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -20,9 +20,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-{{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-{{ hashFiles('requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-pip-{{ hashFiles('requirements.txt') }}
+          ${{ runner.os }}-pip-${{ matrix.python-version }}
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
     - name: Install dependencies

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -40,6 +40,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NAME: github
       run: |
-        coverage run --omit="*/migrations*" --source="." src/manage.py test feedback
+        coverage run src/manage.py test feedback
         coveralls
 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install coveralls
         pip install -r requirements.txt
-        echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> settings.py
+        echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> src/settings.py
     - name: Static Tests
       env:
         PYTHONWARNINGS: all

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install coveralls
+        pip install coveralls wheel setuptools
         pip install -r requirements.txt
         echo "PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher',]" >> src/settings.py
     - name: Static Tests

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -34,7 +34,6 @@ jobs:
         COVERALLS_SERVICE_NAME: github
       run: |
         python src/manage.py check
-        python src/manage.py test feedback
         coverage run --omit="*/migrations*" --source="." src/manage.py test feedback
         coveralls
 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -16,6 +16,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
I did some improvements on the action definition. In the end we have speedup of ~40% e.g. from 1:29 minutes to 51 seconds 
Changes:
* Actions now run for push and pull_requests on every branch
* Build was renamed to test
* The Ubuntu version is pinned to a specific version instead of "latest". (In January 2021 "latest" is still 18.04)
* Added python 3.9
* Added caching for pip
* For test run only md5 is used. Only this saves 12 seconds
* Split tests in Static tests and Unit test
* Static tests also check for missing migrations
* remove duplicate django test run. coverage run also outputs errors
* move coverage settings to .coveragerc file

I think it is now a good blueprint which also could by used for pyophase.